### PR TITLE
Upgrade compileSdkVersion to 30 to fix compile error

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 30
     buildToolsVersion "28.0.3"
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
Fixes this error after running `react-native run-android`:

> FAILURE: Build failed with an exception.
\* What went wrong:
Execution failed for task ':tasks'.
\> Could not create task ':react-native-sms-x:compileDebugJavaWithJavac'.
&nbsp;&nbsp;&nbsp;&nbsp;\> In order to compile Java 9+ source, please set compileSdkVersion to 30 or above
